### PR TITLE
Fix version conflicts caused by PR#126

### DIFF
--- a/src/ReactiveMarbles.PropertyChanged.SourceGenerator.Tests/ReactiveMarbles.PropertyChanged.SourceGenerator.Tests.csproj
+++ b/src/ReactiveMarbles.PropertyChanged.SourceGenerator.Tests/ReactiveMarbles.PropertyChanged.SourceGenerator.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
   

--- a/src/ReactiveMarbles.PropertyChanged.SourceGenerator/ReactiveMarbles.PropertyChanged.SourceGenerator.csproj
+++ b/src/ReactiveMarbles.PropertyChanged.SourceGenerator/ReactiveMarbles.PropertyChanged.SourceGenerator.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.CodeAnalysis.CSharp from 3.8.0 to 3.10.0. [(PR#126)](https://github.com/reactivemarbles/PropertyChanged/pull/126).
Hope this fix can help you.

Best regards,
sucrose